### PR TITLE
[BugFix] Modify to use accessMode RWO when creating scratch pvc

### DIFF
--- a/e2e/virtualmachinimage.go
+++ b/e2e/virtualmachinimage.go
@@ -36,6 +36,9 @@ func virtualMachineImageTest(t *testing.T, ctx *framework.Context) error {
 	if err := testVmiWithInvalidSnapshotClassName(t, ns); err != nil {
 		return err
 	}
+	if err := testVmiWithPvcRwx(t, ns); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -56,6 +59,16 @@ func testVmiWithInvalidSnapshotClassName(t *testing.T, namespace string) error {
 		return err
 	}
 	return waitForVmiStateError(t, namespace, vmiName)
+}
+
+func testVmiWithPvcRwx(t *testing.T, namespace string) error {
+	vmiName := "rwxvmi"
+	vmi := newVmi(namespace, vmiName)
+	vmi.Spec.PVC.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+	if err := framework.Global.Client.Create(context.Background(), vmi, &cleanupOptions); err != nil {
+		return err
+	}
+	return waitForVmi(t, namespace, vmiName)
 }
 
 func waitForVmi(t *testing.T, namespace, name string) error {

--- a/pkg/controller/virtualmachineimage/scratch_pvc.go
+++ b/pkg/controller/virtualmachineimage/scratch_pvc.go
@@ -52,15 +52,19 @@ func getScratchPvcNameFromVmiName(vmiName string) string {
 }
 
 func newScratchPvc(vmi *hc.VirtualMachineImage, scheme *runtime.Scheme) (*corev1.PersistentVolumeClaim, error) {
+	volumeMode := corev1.PersistentVolumeFilesystem
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getScratchPvcNameFromVmiName(vmi.Name),
 			Namespace: vmi.Namespace,
 		},
-		Spec: vmi.Spec.PVC,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeMode:       &volumeMode,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources:        vmi.Spec.PVC.Resources,
+			StorageClassName: vmi.Spec.PVC.StorageClassName,
+		},
 	}
-	volumeMode := corev1.PersistentVolumeFilesystem
-	pvc.Spec.VolumeMode = &volumeMode
 	if err := controllerutil.SetControllerReference(vmi, pvc, scheme); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When creating scratch pvc, volumeMode is `file` and accessMode is using the value written in yaml for vmim creation. In vmim spec, accessMode can be `RWO`, `RWX`, `ROX`.

However, when the volume mode is `file`, only `RWO` can be used as the accessMode. So the accessMode of the scratch pvc should be use RWO.

And add e2e test case to create vmim using RWX.