### PR TITLE
Downgrade operator-sdk version from v0.18.0 to v0.17.1

### DIFF
--- a/deploy/crds/hypercloud.tmaxanc.com_virtualmachineimages_crd.yaml
+++ b/deploy/crds/hypercloud.tmaxanc.com_virtualmachineimages_crd.yaml
@@ -1,8 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachineimages.hypercloud.tmaxanc.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    description: Current state of VirtualMachineImage
+    name: State
+    type: string
   group: hypercloud.tmaxanc.com
   names:
     kind: VirtualMachineImage
@@ -12,230 +17,225 @@ spec:
     - vmim
     singular: virtualmachineimage
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Current state of VirtualMachineImage
-      jsonPath: .status.state
-      name: State
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: VirtualMachineImage is the Schema for the virtualmachineimages
-          API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage
-            properties:
-              pvc:
-                description: PersistentVolumeClaimSpec describes the common attributes
-                  of storage devices and allows a Source for provider-specific attributes
-                properties:
-                  accessModes:
-                    description: 'AccessModes contains the desired access modes the
-                      volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                    items:
-                      type: string
-                    type: array
-                  dataSource:
-                    description: This field requires the VolumeSnapshotDataSource
-                      alpha feature gate to be enabled and currently VolumeSnapshot
-                      is the only supported data source. If the provisioner can support
-                      VolumeSnapshot data source, it will create a new volume and
-                      data will be restored to the volume at the same time. If the
-                      provisioner does not support VolumeSnapshot data source, volume
-                      will not be created and the failure will be reported as an event.
-                      In the future, we plan to support more data source types and
-                      the behavior of the provisioner may change.
-                    properties:
-                      apiGroup:
-                        description: APIGroup is the group for the resource being
-                          referenced. If APIGroup is not specified, the specified
-                          Kind must be in the core API group. For any other third-party
-                          types, APIGroup is required.
-                        type: string
-                      kind:
-                        description: Kind is the type of resource being referenced
-                        type: string
-                      name:
-                        description: Name is the name of resource being referenced
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  resources:
-                    description: 'Resources represents the minimum resources the volume
-                      should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  selector:
-                    description: A label query over volumes to consider for binding.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  storageClassName:
-                    description: 'Name of the StorageClass required by the claim.
-                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VirtualMachineImage is the Schema for the virtualmachineimages
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage
+          properties:
+            pvc:
+              description: PersistentVolumeClaimSpec describes the common attributes
+                of storage devices and allows a Source for provider-specific attributes
+              properties:
+                accessModes:
+                  description: 'AccessModes contains the desired access modes the
+                    volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                  items:
                     type: string
-                  volumeMode:
-                    description: volumeMode defines what type of volume is required
-                      by the claim. Value of Filesystem is implied when not included
-                      in claim spec. This is a beta feature.
-                    type: string
-                  volumeName:
-                    description: VolumeName is the binding reference to the PersistentVolume
-                      backing this claim.
-                    type: string
-                type: object
-              snapshotClassName:
-                type: string
-              source:
-                description: VirtualMachineImageSource provides parameters to create
-                  a VirtualMachineImage from an HTTP source
-                properties:
-                  http:
-                    type: string
-                required:
-                - http
-                type: object
-            required:
-            - pvc
-            - snapshotClassName
-            - source
-            type: object
-          status:
-            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage
-            properties:
-              conditions:
-                description: Conditions indicate current conditions of VirtualMachineImage
-                items:
-                  description: Condition indicates observed condition of an object
+                  type: array
+                dataSource:
+                  description: This field requires the VolumeSnapshotDataSource alpha
+                    feature gate to be enabled and currently VolumeSnapshot is the
+                    only supported data source. If the provisioner can support VolumeSnapshot
+                    data source, it will create a new volume and data will be restored
+                    to the volume at the same time. If the provisioner does not support
+                    VolumeSnapshot data source, volume will not be created and the
+                    failure will be reported as an event. In the future, we plan to
+                    support more data source types and the behavior of the provisioner
+                    may change.
                   properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.  If
-                        that is not known, then using the time when the API field
-                        changed is acceptable.
-                      format: date-time
+                    apiGroup:
+                      description: APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in
+                        the core API group. For any other third-party types, APIGroup
+                        is required.
                       type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                    kind:
+                      description: Kind is the type of resource being referenced
                       type: string
-                    observedGeneration:
-                      description: If set, this represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.condition[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      type: integer
-                    reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                    name:
+                      description: Name is the name of resource being referenced
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                  - kind
+                  - name
                   type: object
-                type: array
-              state:
-                description: State is the current state of VirtualMachineImage
-                type: string
-            required:
-            - state
-            type: object
-        type: object
+                resources:
+                  description: 'Resources represents the minimum resources the volume
+                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                selector:
+                  description: A label query over volumes to consider for binding.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                storageClassName:
+                  description: 'Name of the StorageClass required by the claim. More
+                    info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                  type: string
+                volumeMode:
+                  description: volumeMode defines what type of volume is required
+                    by the claim. Value of Filesystem is implied when not included
+                    in claim spec. This is a beta feature.
+                  type: string
+                volumeName:
+                  description: VolumeName is the binding reference to the PersistentVolume
+                    backing this claim.
+                  type: string
+              type: object
+            snapshotClassName:
+              type: string
+            source:
+              description: VirtualMachineImageSource provides parameters to create
+                a VirtualMachineImage from an HTTP source
+              properties:
+                http:
+                  type: string
+              required:
+              - http
+              type: object
+          required:
+          - pvc
+          - snapshotClassName
+          - source
+          type: object
+        status:
+          description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage
+          properties:
+            conditions:
+              description: Conditions indicate current conditions of VirtualMachineImage
+              items:
+                description: Condition indicates observed condition of an object
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another. This should be when the underlying condition changed.  If
+                      that is not known, then using the time when the API field changed
+                      is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition. This field may be empty.
+                    type: string
+                  observedGeneration:
+                    description: If set, this represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.condition[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    type: integer
+                  reason:
+                    description: The reason for the condition's last transition in
+                      CamelCase. The specific API may choose whether or not this field
+                      is considered a guaranteed API. This field may not be empty.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                      Many .condition.type values are consistent across resources
+                      like Available, but because arbitrary conditions can be useful
+                      (see .node.status.conditions), the ability to deconflict is
+                      important.
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+            state:
+              description: State is the current state of VirtualMachineImage
+              type: string
+          required:
+          - state
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumeexports_crd.yaml
+++ b/deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumeexports_crd.yaml
@@ -1,8 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachinevolumeexports.hypercloud.tmaxanc.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    description: Current state of VirtualMachineVolumeExport
+    name: State
+    type: string
   group: hypercloud.tmaxanc.com
   names:
     kind: VirtualMachineVolumeExport
@@ -12,116 +17,111 @@ spec:
     - vmve
     singular: virtualmachinevolumeexport
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Current state of VirtualMachineVolumeExport
-      jsonPath: .status.state
-      name: State
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: VirtualMachineVolumeExport is the Schema for the virtualmachinevolumeexports
-          API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VirtualMachineVolumeExportSpec defines the desired state
-              of VirtualMachineVolumeExport
-            properties:
-              destination:
-                description: VirtualMachineVolumeExportDestination defines the destination
-                  to export volume
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VirtualMachineVolumeExport is the Schema for the virtualmachinevolumeexports
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VirtualMachineVolumeExportSpec defines the desired state of
+            VirtualMachineVolumeExport
+          properties:
+            destination:
+              description: VirtualMachineVolumeExportDestination defines the destination
+                to export volume
+              properties:
+                local:
+                  description: VirtualMachineVolumeExportDestinationLocal defines
+                    the Local destination to export volume
+                  type: object
+              type: object
+            virtualMachineVolume:
+              description: VirtualMachineVolumeSource indicates the VirtualMachineVolume
+                to be exported
+              properties:
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - destination
+          - virtualMachineVolume
+          type: object
+        status:
+          description: VirtualMachineVolumeExportStatus defines the observed state
+            of VirtualMachineVolumeExport
+          properties:
+            conditions:
+              description: Conditions indicate current conditions of VirtualMachineVolumeExport
+              items:
+                description: Condition indicates observed condition of an object
                 properties:
-                  local:
-                    description: VirtualMachineVolumeExportDestinationLocal defines
-                      the Local destination to export volume
-                    type: object
-                type: object
-              virtualMachineVolume:
-                description: VirtualMachineVolumeSource indicates the VirtualMachineVolume
-                  to be exported
-                properties:
-                  name:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another. This should be when the underlying condition changed.  If
+                      that is not known, then using the time when the API field changed
+                      is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition. This field may be empty.
+                    type: string
+                  observedGeneration:
+                    description: If set, this represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.condition[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    type: integer
+                  reason:
+                    description: The reason for the condition's last transition in
+                      CamelCase. The specific API may choose whether or not this field
+                      is considered a guaranteed API. This field may not be empty.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                      Many .condition.type values are consistent across resources
+                      like Available, but because arbitrary conditions can be useful
+                      (see .node.status.conditions), the ability to deconflict is
+                      important.
                     type: string
                 required:
-                - name
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
                 type: object
-            required:
-            - destination
-            - virtualMachineVolume
-            type: object
-          status:
-            description: VirtualMachineVolumeExportStatus defines the observed state
-              of VirtualMachineVolumeExport
-            properties:
-              conditions:
-                description: Conditions indicate current conditions of VirtualMachineVolumeExport
-                items:
-                  description: Condition indicates observed condition of an object
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.  If
-                        that is not known, then using the time when the API field
-                        changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
-                      type: string
-                    observedGeneration:
-                      description: If set, this represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.condition[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      type: integer
-                    reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              state:
-                description: State is the current state of VirtualMachineVolumeExport
-                type: string
-            required:
-            - state
-            type: object
-        type: object
+              type: array
+            state:
+              description: State is the current state of VirtualMachineVolumeExport
+              type: string
+          required:
+          - state
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumes_crd.yaml
+++ b/deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumes_crd.yaml
@@ -1,8 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachinevolumes.hypercloud.tmaxanc.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    description: Current state of VirtualMachineVolume
+    name: State
+    type: string
   group: hypercloud.tmaxanc.com
   names:
     kind: VirtualMachineVolume
@@ -12,65 +17,60 @@ spec:
     - vmv
     singular: virtualmachinevolume
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VirtualMachineVolume is the Schema for the virtualmachinevolumes
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VirtualMachineVolumeSpec defines the desired state of VirtualMachineVolume
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity defines size of the VirtualMachineVolume
+              type: object
+            virtualMachineImage:
+              description: VirtualMachineImage defines name of the VirtualMachineImage
+              properties:
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - virtualMachineImage
+          type: object
+        status:
+          description: VirtualMachineVolumeStatus defines the observed state of VirtualMachineVolume
+          properties:
+            state:
+              description: State is the current state of VirtualMachineVolume
+              type: string
+          required:
+          - state
+          type: object
+      type: object
+  version: v1alpha1
   versions:
-  - additionalPrinterColumns:
-    - description: Current state of VirtualMachineVolume
-      jsonPath: .status.state
-      name: State
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: VirtualMachineVolume is the Schema for the virtualmachinevolumes
-          API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VirtualMachineVolumeSpec defines the desired state of VirtualMachineVolume
-            properties:
-              capacity:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Capacity defines size of the VirtualMachineVolume
-                type: object
-              virtualMachineImage:
-                description: VirtualMachineImage defines name of the VirtualMachineImage
-                properties:
-                  name:
-                    type: string
-                required:
-                - name
-                type: object
-            required:
-            - virtualMachineImage
-            type: object
-          status:
-            description: VirtualMachineVolumeStatus defines the observed state of
-              VirtualMachineVolume
-            properties:
-              state:
-                description: State is the current state of VirtualMachineVolume
-                type: string
-            required:
-            - state
-            type: object
-        type: object
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/testbox
+++ b/testbox
@@ -95,7 +95,7 @@ rook_install)
   rook_install_command
   ;;
 operator-sdk_install)
-  curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.18.0/operator-sdk-v0.18.0-x86_64-linux-gnu
+  curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.17.1/operator-sdk-v0.17.1-x86_64-linux-gnu
   chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin
   ;;
 build)


### PR DESCRIPTION
The default CRD apiVersion is changed on operator-sdk v0.18.0 from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. However CRD apiVersion `apiextensions.k8s.io/v1` is only supported after k8s v1.16. 
CRD apiVersion is needed to downgrade from `apiextensions.k8s.io/v1` to `apiextensions.k8s.io/v1beta1` to support k8s v.1.15 environments.

Maybe we can apply  v0.18.0 in the next release v.1.2.0. 

- resolves #21