### PR TITLE
[Documentation] fix user guide

### DIFF
--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -42,7 +42,9 @@ $ kubectl apply -f deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumes_crd.
 $ kubectl apply -f deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumeexports_crd.yaml
 
 # Deploy operator
-$ kubectl apply -f deploy/common.yaml
+$ kubectl apply -f deploy/role.yaml
+$ kubectl apply -f deploy/role_binding.yaml
+$ kubectl apply -f deploy/service_account.yaml
 $ kubectl apply -f deploy/operator.yaml
 
 # Check operator status


### PR DESCRIPTION
Didn't add `common.yaml` in previous PR #31, because it was unable to merge role, role_binding, service_account yamls into one yaml file (common.yaml) in order to execute e2e test. However, user guide has been updated by accident to use `common.yaml` in the PR. This commit will revert the unintended change has been made.