### PR TITLE
[Bugfix] operator is not working after adding kis namespace

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace: "",
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -42,6 +42,7 @@ $ kubectl apply -f deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumes_crd.
 $ kubectl apply -f deploy/crds/hypercloud.tmaxanc.com_virtualmachinevolumeexports_crd.yaml
 
 # Deploy operator
+$ kubectl apply -f deploy/namespace.yaml
 $ kubectl apply -f deploy/role.yaml
 $ kubectl apply -f deploy/role_binding.yaml
 $ kubectl apply -f deploy/service_account.yaml


### PR DESCRIPTION
- By default, operator watches only the namespace that the operator is running in. To watch all namespaces, it seems like somethings are need to be done. 
  - next step: `deploy/operator.yaml`: Set WATCH_NAMESPACE="" instead of setting it to the Pod’s namespace.
  - [useful link](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html/applications/operator-sdk) 11.1.1.2. Manager file
- update user guide 