### PR TITLE
WIP: Separating namespace for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,8 +16,7 @@ spec:
       serviceAccountName: kubevirt-image-service
       containers:
         - name: kubevirt-image-service
-          #image: quay.io/tmaxanc/kubevirt-image-service:latest
-          image: quay.io/tmaxanc/kubevirt-image-service:canary
+          image: quay.io/tmaxanc/kubevirt-image-service:latest
           command:
           - kubevirt-image-service
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,15 +16,14 @@ spec:
       serviceAccountName: kubevirt-image-service
       containers:
         - name: kubevirt-image-service
-          image: quay.io/tmaxanc/kubevirt-image-service:latest
+          #image: quay.io/tmaxanc/kubevirt-image-service:latest
+          image: quay.io/tmaxanc/kubevirt-image-service:canary
           command:
           - kubevirt-image-service
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,9 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: kubevirt-image-service
-  namespace: kis
 rules:
 - apiGroups:
   - ""

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,13 +1,13 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubevirt-image-service
-  namespace: kis
 subjects:
 - kind: ServiceAccount
   name: kubevirt-image-service
+  namespace: kis
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: kubevirt-image-service
   apiGroup: rbac.authorization.k8s.io
 

--- a/testbox
+++ b/testbox
@@ -111,7 +111,10 @@ unit)
 codegen)
   codegen
 ;;
-e2e) operator-sdk test local ./e2e --operator-namespace kis --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
+e2e) 
+  kubectl create ns kis
+  operator-sdk test local ./e2e --operator-namespace kis --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
+  kubectl delete ns kis
 *)
   print_help
 ;;

--- a/testbox
+++ b/testbox
@@ -113,8 +113,9 @@ codegen)
 ;;
 e2e) 
   kubectl create ns kis
-  operator-sdk test local ./e2e --operator-namespace kis --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
+  operator-sdk test local ./e2e --operator-namespace kis --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary
   kubectl delete ns kis
+  ;;
 *)
   print_help
 ;;

--- a/testbox
+++ b/testbox
@@ -111,7 +111,7 @@ unit)
 codegen)
   codegen
 ;;
-e2e) operator-sdk test local ./e2e --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
+e2e) operator-sdk test local ./e2e --operator-namespace kis --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
 *)
   print_help
 ;;


### PR DESCRIPTION
Two major changes
First, separate operator and service account into kis namespace,
Second, operator can watch CRD cluster-wide.

This PR has a few ISSUE: #39 
When performing e2e test, POD and SA are created in arbitrary namespace, not in kis