### PR TITLE
Separating namespace for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,9 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: kubevirt-image-service
-  namespace: kis
 rules:
 - apiGroups:
   - ""

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,13 +1,13 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubevirt-image-service
-  namespace: kis
 subjects:
 - kind: ServiceAccount
   name: kubevirt-image-service
+  namespace: kis
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: kubevirt-image-service
   apiGroup: rbac.authorization.k8s.io
 

--- a/testbox
+++ b/testbox
@@ -111,7 +111,14 @@ unit)
 codegen)
   codegen
 ;;
-e2e) operator-sdk test local ./e2e --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary;;
+e2e) 
+  kubectl create -f ./deploy/namespace.yaml
+  operator-sdk test local --operator-namespace kis ./e2e --debug --verbose --image quay.io/tmaxanc/kubevirt-image-service:canary
+  kubectl delete -f ./deploy/namespace.yaml
+  # Will not be necessary when sdk version goes up
+  kubectl delete -f ./deploy/role.yaml
+  kubectl delete -f ./deploy/role_binding.yaml
+  ;;
 *)
   print_help
 ;;


### PR DESCRIPTION
Two major changes
First, separate operator and service account into kis namespace,
Second, operator can watch CRD cluster-wide.

For this, Role and RoleBinding have been changed to cluster wide.

This PR has a few ISSUE :
After e2e test, RBAC information is not cleaned up.

resolve: #39 
