### PR TITLE
Using condition array to check if vmv is available in vmvexport

### DIFF
--- a/pkg/controller/virtualmachinevolumeexport/virtualmachinevolumeexport_controller.go
+++ b/pkg/controller/virtualmachinevolumeexport/virtualmachinevolumeexport_controller.go
@@ -152,9 +152,10 @@ func (r *ReconcileVirtualMachineVolumeExport) validateVirtualMachineVolume() err
 	}
 	// check if vmv is available
 	found, cond := util.GetConditionByType(vmVolume.Status.Conditions, hc.ConditionReadyToUse)
-	if !found || cond.Status != corev1.ConditionTrue {
-		klog.Info("VirtualMachineVolume state is not available")
-		return goerrors.New("VirtualMachineVolume state is not available")
+	if !found || cond.Status == corev1.ConditionUnknown {
+		return goerrors.New("VirtualMachineVolume state is not determined yet")
+	} else if cond.Status == corev1.ConditionFalse {
+		return goerrors.New("VirtualMachineVolume state is not in the condition")
 	}
 	return nil
 }

--- a/pkg/controller/virtualmachinevolumeexport/virtualmachinevolumeexport_controller.go
+++ b/pkg/controller/virtualmachinevolumeexport/virtualmachinevolumeexport_controller.go
@@ -151,8 +151,10 @@ func (r *ReconcileVirtualMachineVolumeExport) validateVirtualMachineVolume() err
 		return goerrors.New("fail to get virtual machine volume")
 	}
 	// check if vmv is available
-	if vmVolume.Status.State != hc.VirtualMachineVolumeStateAvailable {
-		return goerrors.New("virtual machine volume is not available")
+	found, cond := util.GetConditionByType(vmVolume.Status.Conditions, hc.ConditionReadyToUse)
+	if !found || cond.Status != corev1.ConditionTrue {
+		klog.Info("VirtualMachineVolume state is not available")
+		return goerrors.New("VirtualMachineVolume state is not available")
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, 'State' was used to check the state of vmv.
Now, it has been modified to use the condition array.

resolve: #19 