### PR TITLE
[Documentation] Dropping the leading slash in kubectl cp

### DIFF
--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -128,6 +128,7 @@ NAME                              READY   STATUS    RESTARTS   AGE
 disk-export-exporter-local        1/1     Running   6          67m
 
 # Copy exported volume to local path
-# kubectl cp {vmve exporter pod name}:/export {local path to download}
-$ kubectl cp disk-export-exporter-local:/export export
+# export/disk.img is in qcow2 format
+# kubectl cp {vmve exporter pod name}:export/disk.img {local path to download}
+$ kubectl cp disk-export-exporter-local:export/disk.img localpath.img
 ```


### PR DESCRIPTION
Leading slash path complain "tar: removing leading '/' from member names" error.
Also, the exact path to the image in the exporter pod is export/disk.img