### PR TITLE
Add pending state in VMVE and VMV

### DIFF
--- a/pkg/apis/hypercloud/v1alpha1/virtualmachinevolume_types.go
+++ b/pkg/apis/hypercloud/v1alpha1/virtualmachinevolume_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // VirtualMachineImageName identifies which VirtualMachineImage source to create a VirtualMachineVolume from
@@ -24,11 +23,6 @@ type VirtualMachineVolumeSpec struct {
 
 // VirtualMachineVolumeState is a short string representation of the current VirtualMachineVolume state
 type VirtualMachineVolumeState string
-
-const (
-	// VirtualMachineVolumeReconcileAgain is time to enter the reconcile loop again
-	VirtualMachineVolumeReconcileAgain = 1 * time.Second
-)
 
 const (
 	// VirtualMachineVolumeStateCreating indicates VirtualMachineVolume is creating pvc

--- a/pkg/apis/hypercloud/v1alpha1/virtualmachinevolume_types.go
+++ b/pkg/apis/hypercloud/v1alpha1/virtualmachinevolume_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 // VirtualMachineImageName identifies which VirtualMachineImage source to create a VirtualMachineVolume from
@@ -25,12 +26,19 @@ type VirtualMachineVolumeSpec struct {
 type VirtualMachineVolumeState string
 
 const (
+	// VirtualMachineVolumeReconcileAgain is time to enter the reconcile loop again
+	VirtualMachineVolumeReconcileAgain = 1 * time.Second
+)
+
+const (
 	// VirtualMachineVolumeStateCreating indicates VirtualMachineVolume is creating pvc
 	VirtualMachineVolumeStateCreating VirtualMachineVolumeState = "Creating"
 	// VirtualMachineVolumeStateAvailable indicates VirtualMachineVolume is ready to use
 	VirtualMachineVolumeStateAvailable VirtualMachineVolumeState = "Available"
 	// VirtualMachineVolumeStateError indicates VirtualMachineVolume is not able to use
 	VirtualMachineVolumeStateError VirtualMachineVolumeState = "Error"
+	// VirtualMachineVolumeStatePending indicates VirtualMachineVolume is not able to use
+	VirtualMachineVolumeStatePending VirtualMachineVolumeState = "Pending"
 )
 
 const (

--- a/pkg/apis/hypercloud/v1alpha1/virtualmachinevolumeexport_types.go
+++ b/pkg/apis/hypercloud/v1alpha1/virtualmachinevolumeexport_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 // VirtualMachineVolumeExportSpec defines the desired state of VirtualMachineVolumeExport
@@ -41,12 +42,19 @@ const (
 type VirtualMachineVolumeExportState string
 
 const (
+	// VirtualMachineVolumeExportReconcileAgain is time to enter the reconcile loop again
+	VirtualMachineVolumeExportReconcileAgain = 1 * time.Second
+)
+
+const (
 	// VirtualMachineVolumeExportStateCreating indicates VirtualMachineVolumeExport is creating
 	VirtualMachineVolumeExportStateCreating VirtualMachineVolumeExportState = "Creating"
 	// VirtualMachineVolumeExportStateCompleted indicates the pvc export is completed
 	VirtualMachineVolumeExportStateCompleted VirtualMachineVolumeExportState = "Completed"
 	// VirtualMachineVolumeExportStateError indicates VirtualMachineVolumeExport is error
 	VirtualMachineVolumeExportStateError VirtualMachineVolumeExportState = "Error"
+	// VirtualMachineVolumeExportStatePending indicates VirtualMachineVolumeExport is pending
+	VirtualMachineVolumeExportStatePending VirtualMachineVolumeExportState = "Pending"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/hypercloud/v1alpha1/virtualmachinevolumeexport_types.go
+++ b/pkg/apis/hypercloud/v1alpha1/virtualmachinevolumeexport_types.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // VirtualMachineVolumeExportSpec defines the desired state of VirtualMachineVolumeExport
@@ -40,11 +39,6 @@ const (
 
 // VirtualMachineVolumeExportState is the current state of the VirtualMachineVolumeExport
 type VirtualMachineVolumeExportState string
-
-const (
-	// VirtualMachineVolumeExportReconcileAgain is time to enter the reconcile loop again
-	VirtualMachineVolumeExportReconcileAgain = 1 * time.Second
-)
 
 const (
 	// VirtualMachineVolumeExportStateCreating indicates VirtualMachineVolumeExport is creating

--- a/pkg/controller/virtualmachinevolume/virtualmachinevolume_controller_test.go
+++ b/pkg/controller/virtualmachinevolume/virtualmachinevolume_controller_test.go
@@ -19,8 +19,8 @@ var _ = Describe("Reconcile", func() {
 		r := createFakeReconcileVmv()
 		_, err := r.Reconcile(reconcile.Request{NamespacedName: testVolumeNamespacedName})
 
-		It("Should return error", func() {
-			Expect(err).ShouldNot(BeNil())
+		It("Should be nil", func() {
+			Expect(err).Should(BeNil())
 		})
 		It("Should not create pvc", func() {
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -28,11 +28,11 @@ var _ = Describe("Reconcile", func() {
 				Namespace: r.volume.Namespace}, pvc)
 			Expect(errors.IsNotFound(err)).Should(BeTrue())
 		})
-		It("Should update state to error", func() {
+		It("Should update state to pending", func() {
 			volume := &hc.VirtualMachineVolume{}
 			err = r.client.Get(context.TODO(), testVolumeNamespacedName, volume)
 			Expect(err).Should(BeNil())
-			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStateError))
+			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStatePending))
 		})
 		It("Should update condition readyToUse to false", func() {
 			volume := &hc.VirtualMachineVolume{}
@@ -50,12 +50,12 @@ var _ = Describe("Reconcile", func() {
 
 	Context("2. with false status image", func() {
 		image := newTestImage()
-		util.SetConditionByType(image.Status.Conditions, hc.ConditionReadyToUse, corev1.ConditionTrue, "VmiIsReady", "Vmi is ready to use")
 		r := createFakeReconcileVmv(image)
+		image.Status.Conditions = util.SetConditionByType(image.Status.Conditions, hc.ConditionReadyToUse, corev1.ConditionFalse, "VmiIsReady", "Vmi is ready to use")
 		_, err := r.Reconcile(reconcile.Request{NamespacedName: testVolumeNamespacedName})
 
-		It("Should return error", func() {
-			Expect(err).ShouldNot(BeNil())
+		It("Should be nil", func() {
+			Expect(err).Should(BeNil())
 		})
 		It("Should not create pvc", func() {
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -63,11 +63,11 @@ var _ = Describe("Reconcile", func() {
 				Namespace: r.volume.Namespace}, pvc)
 			Expect(errors.IsNotFound(err)).Should(BeTrue())
 		})
-		It("Should update state to error", func() {
+		It("Should update state to pending", func() {
 			volume := &hc.VirtualMachineVolume{}
 			err = r.client.Get(context.TODO(), testVolumeNamespacedName, volume)
 			Expect(err).Should(BeNil())
-			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStateError))
+			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStatePending))
 		})
 		It("Should update condition readyToUse to false", func() {
 			volume := &hc.VirtualMachineVolume{}
@@ -88,8 +88,8 @@ var _ = Describe("Reconcile", func() {
 		r := createFakeReconcileVmv(image)
 		_, err := r.Reconcile(reconcile.Request{NamespacedName: testVolumeNamespacedName})
 
-		It("Should return error", func() {
-			Expect(err).ShouldNot(BeNil())
+		It("Should be nil", func() {
+			Expect(err).Should(BeNil())
 		})
 		It("Should not create pvc", func() {
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -97,11 +97,11 @@ var _ = Describe("Reconcile", func() {
 				Namespace: r.volume.Namespace}, pvc)
 			Expect(errors.IsNotFound(err)).Should(BeTrue())
 		})
-		It("Should update state to error", func() {
+		It("Should update state to pending", func() {
 			volume := &hc.VirtualMachineVolume{}
 			err = r.client.Get(context.TODO(), testVolumeNamespacedName, volume)
 			Expect(err).Should(BeNil())
-			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStateError))
+			Expect(volume.Status.State).Should(Equal(hc.VirtualMachineVolumeStatePending))
 		})
 		It("Should update condition readyToUse to false", func() {
 			volume := &hc.VirtualMachineVolume{}
@@ -120,7 +120,7 @@ var _ = Describe("Reconcile", func() {
 	Context("4. with true status, invalid size image", func() {
 		image := newTestImage()
 		image.Spec.PVC.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("7Gi")
-		util.SetConditionByType(image.Status.Conditions, hc.ConditionReadyToUse, corev1.ConditionTrue, "VmiIsReady", "Vmi is ready to use")
+		image.Status.Conditions = util.SetConditionByType(image.Status.Conditions, hc.ConditionReadyToUse, corev1.ConditionTrue, "VmiIsReady", "Vmi is ready to use")
 		r := createFakeReconcileVmv(image)
 		_, err := r.Reconcile(reconcile.Request{NamespacedName: testVolumeNamespacedName})
 
@@ -143,7 +143,6 @@ var _ = Describe("Reconcile", func() {
 			volume := &hc.VirtualMachineVolume{}
 			err = r.client.Get(context.TODO(), testVolumeNamespacedName, volume)
 			Expect(err).Should(BeNil())
-			// clear lastTransitionTime for easy comparison
 			for i := range volume.Status.Conditions {
 				volume.Status.Conditions[i].LastTransitionTime = v1.Time{}
 			}


### PR DESCRIPTION
In VMVE, all abnormal situations are defined as 'error' state.
However, Cases in which the VMVE could not be restored to the normal state were classified as 'pending' state.